### PR TITLE
delete Wire.begin()

### DIFF
--- a/src/ClosedCube_HDC1080.cpp
+++ b/src/ClosedCube_HDC1080.cpp
@@ -39,7 +39,6 @@ ClosedCube_HDC1080::ClosedCube_HDC1080()
 
 void ClosedCube_HDC1080::begin(uint8_t address) {
 	_address = address;
-	Wire.begin();
 
 	setResolution(HDC1080_RESOLUTION_14BIT, HDC1080_RESOLUTION_14BIT);
 }


### PR DESCRIPTION
Wire.begin() should outside library